### PR TITLE
Update SendQueryTask.java

### DIFF
--- a/src/main/java/Germany/RWTH/JRCCombine/internal/Omnipath/SendQueryTask.java
+++ b/src/main/java/Germany/RWTH/JRCCombine/internal/Omnipath/SendQueryTask.java
@@ -63,8 +63,8 @@ public class SendQueryTask extends AbstractTask implements ObservableTask {
 		String property = "java.io.tmpdir";
 		String tempDir = System.getProperty(property);
 		String out = new SimpleDateFormat("yyyy-MM-dd_hh-mm-ss'.txt'").format(new Date());
-		filename = tempDir+tmp+out;
-		filePath = new File(filename);
+		filename = tmp+out;
+		filePath = new File(tempDir, filename);
 		
 		
 		ReadableByteChannel rbc = Channels.newChannel(website.openStream());


### PR DESCRIPTION
fixing issue: permission denied to create file by Cytoscape plugin (@deeenes ) 
https://github.com/saezlab/pypath/issues/67

found this on Stackoverflow: 
https://stackoverflow.com/questions/14845045/permission-denied-when-writing-file-to-default-temp-directory
possible problem: tmp folder returned by java.io.tmpdir is /tmp without the "/" in the end